### PR TITLE
Add space after colon in delete form

### DIFF
--- a/src/dataTables.altEditor.free.js
+++ b/src/dataTables.altEditor.free.js
@@ -430,7 +430,7 @@ console.log(rowDataArray); //DEBUG
                             + that._quoteattr(columnDefs[j].title)
                             + "'>"
                             + columnDefs[j].title
-                            + ":  </label> <input  type='hidden'  id='"
+                            + ":&nbsp</label> <input  type='hidden'  id='"
                             + that._quoteattr(columnDefs[j].title)
                             + "' name='"
                             + that._quoteattr(columnDefs[j].title)


### PR DESCRIPTION
Delete form doesn't render a space between colon and value:

Id:7

it should be:

Id: 7