### PR TITLE
variable name doesn't exist in _errorCallback

### DIFF
--- a/src/dataTables.altEditor.free.js
+++ b/src/dataTables.altEditor.free.js
@@ -709,7 +709,7 @@ console.log(rowDataArray); //DEBUG
              * Called after AJAX server returned an error
              */
             _errorCallback: function (response, status, more) {
-                    var error = resp;
+                    var error = response;
                     $('#altEditor-modal .modal-body .alert').remove();
                     var errstr = "There was an unknown error!";
                     if (error.responseJSON && error.responseJSON.errors) {


### PR DESCRIPTION
Variable "resp" in _errorCallback doesn't exist it should be named "response".